### PR TITLE
Inform about correct place to retrieve staged QCA firmware binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# Upstream Wifi Firmware
-	
-Wifi Firmware files for chipsets and platforms supported by Open source Qualcomm Drivers.
+upstream-wifi-fw.git [has moved to](https://lore.kernel.org/r/bac97f31-4a70-4c4c-8179-4ede0b32f869@quicinc.com/):
+
+* https://git.codelinaro.org/clo/ath-firmware/ath10k-firmware
+* https://git.codelinaro.org/clo/ath-firmware/ath11k-firmware
+* https://git.codelinaro.org/clo/ath-firmware/ath12k-firmware
+
+This github.com repository is not updated anymore and will be deleted June 2024.


### PR DESCRIPTION
As announced by Jeff Johnson + Kalle Valo (from QUIC):  https://lore.kernel.org/all/bac97f31-4a70-4c4c-8179-4ede0b32f869@quicinc.com/